### PR TITLE
Register OreDict recipes during registry event. Fixes #5

### DIFF
--- a/src/main/java/minechem/init/ModEvents.java
+++ b/src/main/java/minechem/init/ModEvents.java
@@ -401,19 +401,6 @@ public class ModEvents {
 	}
 
 	@SubscribeEvent
-	public void onOreEvent(OreDictionary.OreRegisterEvent event) {
-		String oreName = event.getName();
-		if (ModRecipes.getOreDictionaryHandlers() != null) {
-			for (IOreDictionaryHandler handler : ModRecipes.getOreDictionaryHandlers()) {
-				if (handler.canHandle(oreName)) {
-					handler.handle(oreName);
-					return;
-				}
-			}
-		}
-	}
-
-	@SubscribeEvent
 	public void onDecayEvent(RadiationDecayEvent event) {
 		if (event.getPlayer() != null) {
 			String nameBeforeDecay = event.getLongName(event.getBefore());

--- a/src/main/java/minechem/init/ModRecipes.java
+++ b/src/main/java/minechem/init/ModRecipes.java
@@ -2001,6 +2001,18 @@ public class ModRecipes {
 		registry.register(new RecipePotionCoating());
 		registry.register(new RecipePotionSpiking());
 		registry.register(new RecipeCloneChemistJournal());
+
+		for (String oreName : OreDictionary.getOreNames()) {
+			ModLogger.debug("Checking oredict " + oreName);
+			if (ModRecipes.getOreDictionaryHandlers() != null) {
+				for (IOreDictionaryHandler handler : ModRecipes.getOreDictionaryHandlers()) {
+					if (handler.canHandle(oreName)) {
+						handler.handle(oreName);
+						break;
+					}
+				}
+			}
+		}
 	}
 
 	//TODO


### PR DESCRIPTION
Because ThermalFoundation can load first, when TF registered oredict (in the preInit stage), Minechem tries to create the recipe but since Minechem items aren't even initialized, this causing the recipe to be blank.
It's also recommended that the recipe system checks all inputs and throws an Exception when all inputs are empty.